### PR TITLE
Ensure typing area focuses on load

### DIFF
--- a/src/app/components/TypingArea.tsx
+++ b/src/app/components/TypingArea.tsx
@@ -27,7 +27,7 @@ const TypingArea: React.FC<TypingAreaProps> = ({
 
   useEffect(() => {
     typingContainerRef.current?.focus();
-  }, []);
+  }, [lines]);
 
   const handleTyping = (e: React.KeyboardEvent<HTMLDivElement>) => {
     onTypingStart();
@@ -50,14 +50,10 @@ const TypingArea: React.FC<TypingAreaProps> = ({
       if (charIndex > 0) {
         const prevCharIndex = charIndex - 1;
 
-        setTypedChars((prev) => {
-          const updated = [...prev];
-          updated[prevCharIndex] = "pending"; // Set to neutral
-          return updated;
-        });
+        setTypedChars((prev) => prev.slice(0, prevCharIndex));
 
         setCharIndex(prevCharIndex);
-        setTypedText((prev) => prev.slice(0, -1)); // Remove last character from typedText
+        setTypedText((prev) => prev.slice(0, -1));
       }
       return;
     }
@@ -133,13 +129,15 @@ const TypingArea: React.FC<TypingAreaProps> = ({
                       lineIndex === 0 && index < typedChars.length
                         ? typedChars[index] === "correct"
                           ? "text-white"
-                          : "text-red-500"
+                          : char === " "
+                            ? "bg-red-500"
+                            : "text-red-500"
                         : "text-gray-500"
                     } ${
                       isCursor && cursorVisible ? "bg-gray-600 text-black" : ""
                     }`}
                   >
-                    {char}
+                    {char === " " ? "\u00A0" : char}
                   </span>
                 );
               })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,8 +55,18 @@ const Main: React.FC = () => {
   return (
     <div>
       <div className="min-h-screen overflow-x-auto flex flex-col items-center justify-center">
-        {!isTypingStarted && <Header />}
-        {!isTypingStarted && (
+        <div
+          className={`transition-opacity duration-500 ${
+            isTypingStarted ? "opacity-0 pointer-events-none" : "opacity-100"
+          }`}
+        >
+          <Header />
+        </div>
+        <div
+          className={`transition-opacity duration-500 ${
+            isTypingStarted ? "opacity-0 pointer-events-none" : "opacity-100"
+          }`}
+        >
           <SelectorBar
             onAlgorithmSelect={(algorithm: AlgorithmName) =>
               setSelectedAlgorithm(algorithm)
@@ -67,7 +77,7 @@ const Main: React.FC = () => {
             }
             selectedLanguage={selectedLanguage}
           />
-        )}
+        </div>
         {typingComplete ? (
           <FadeSwitch
             algorithmName={selectedAlgorithm}


### PR DESCRIPTION
## Summary
- refocus TypingArea when content lines change so the editor always has focus on page load
- keep Header and SelectorBar in the DOM and fade them out when typing starts so the editor doesn't shift upward
- highlight background when a space character is mistyped so the error is visible
- return characters to the default styling when backspaced so mistakes can be corrected cleanly

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872bc5013b0832c967643f0557a1f68