### PR TITLE
Add closing animations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,18 @@ body {
 .dropdown-animation {
   animation: fade-in-down 0.2s ease-in-out;
 }
+
+@keyframes fade-out-up {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-0.25rem);
+  }
+}
+
+.dropdown-close-animation {
+  animation: fade-out-up 0.2s ease-in-out forwards;
+}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,17 +1,50 @@
-import React, { createContext, useContext, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+} from "react";
 
 interface DropdownContextProps {
   open: boolean;
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  closeMenu: () => void;
+  closing: boolean;
 }
 
 const DropdownMenuContext = createContext<DropdownContextProps | null>(null);
 
 export const DropdownMenu: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [open, setOpen] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const closeMenu = useCallback(() => {
+    if (!open) return;
+    setClosing(true);
+    setOpen(false);
+    setTimeout(() => setClosing(false), 200);
+  }, [open]);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        closeMenu();
+      }
+    };
+    if (open) {
+      document.addEventListener("mousedown", handleClick);
+    } else {
+      document.removeEventListener("mousedown", handleClick);
+    }
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open, closeMenu]);
+
   return (
-    <DropdownMenuContext.Provider value={{ open, setOpen }}>
-      <div className="relative inline-block text-left">{children}</div>
+    <DropdownMenuContext.Provider value={{ open, setOpen, closeMenu, closing }}>
+      <div ref={menuRef} className="relative inline-block text-left">{children}</div>
     </DropdownMenuContext.Provider>
   );
 };
@@ -20,11 +53,11 @@ export const DropdownMenuTrigger = React.forwardRef<HTMLButtonElement, React.But
   ({ children, ...props }, ref) => {
     const context = useContext(DropdownMenuContext);
     if (!context) throw new Error("DropdownMenu components must be used within DropdownMenu");
-    const { open, setOpen } = context;
+    const { open, setOpen, closeMenu } = context;
     return (
       <button
         ref={ref}
-        onClick={() => setOpen(!open)}
+        onClick={() => (open ? closeMenu() : setOpen(true))}
         {...props}
       >
         {children}
@@ -37,11 +70,11 @@ DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
 export const DropdownMenuContent: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className }) => {
   const context = useContext(DropdownMenuContext);
   if (!context) throw new Error("DropdownMenu components must be used within DropdownMenu");
-  const { open } = context;
-  if (!open) return null;
+  const { open, closing } = context;
+  if (!open && !closing) return null;
   return (
     <div
-      className={`absolute right-0 mt-2 min-w-[8rem] rounded-md bg-white shadow-lg z-10 dropdown-animation ${
+      className={`absolute right-0 mt-2 min-w-[8rem] rounded-md bg-white shadow-lg z-10 ${open ? "dropdown-animation" : "dropdown-close-animation"} ${
         className || ""
       }`}
     >
@@ -53,12 +86,12 @@ export const DropdownMenuContent: React.FC<{ children: React.ReactNode; classNam
 export const DropdownMenuItem: React.FC<{ onSelect?: () => void; className?: string; children: React.ReactNode }> = ({ onSelect, className, children }) => {
   const context = useContext(DropdownMenuContext);
   if (!context) throw new Error("DropdownMenu components must be used within DropdownMenu");
-  const { setOpen } = context;
+  const { closeMenu } = context;
   const handleSelect = () => {
     if (onSelect) {
       onSelect();
     }
-    setOpen(false);
+    closeMenu();
   };
   return (
     <button onClick={handleSelect} className={`block w-full px-4 py-2 text-left text-sm hover:bg-gray-100 ${className || ""}`}>{children}</button>


### PR DESCRIPTION
## Summary
- add fade-out animation for dropdown closing
- close Combobox and Dropdown when clicking outside
- animate opening and closing of Combobox and Dropdown

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687347724990832caaf08e8c2aa5a9b4